### PR TITLE
Ensure we close the status healthcheck response body

### DIFF
--- a/status.go
+++ b/status.go
@@ -146,6 +146,7 @@ func (s *statusHandler) checkBackendStatus() error {
 		if err != nil {
 			return err
 		}
+		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("target returned status: %d", resp.StatusCode)


### PR DESCRIPTION
### TL;DR
Ensures we close the rsponse body after a successfuly response from the status healthcheck request. This could avoid a potential connection leak which could also cause a memory leak.

### Other notes
- We don't nesccariily need to use a `GET` here, which returns ` body`,  where a `HEAD` could be more suitable/efficient
- We also may be able to reuse the `http.Client` object across healthchecks, which will also be much more effcient